### PR TITLE
BaseEntity 추가. JPA 기본 설정을 따름 id Long

### DIFF
--- a/src/main/kotlin/com/hschoi/todo/common/entities/BaseEntity.kt
+++ b/src/main/kotlin/com/hschoi/todo/common/entities/BaseEntity.kt
@@ -1,0 +1,27 @@
+package com.hschoi.todo.common.entities
+
+import org.hibernate.annotations.CreationTimestamp
+import org.hibernate.annotations.UpdateTimestamp
+import java.time.LocalDateTime
+import javax.persistence.GeneratedValue
+import javax.persistence.GenerationType
+import javax.persistence.Id
+import javax.persistence.MappedSuperclass
+
+/**
+ * Created by hschoi.
+ * User: nate
+ * Date: 2020/04/04
+ */
+@MappedSuperclass
+abstract class BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    open var id: Long? = null
+
+    @CreationTimestamp
+    val createdAt: LocalDateTime = LocalDateTime.now()
+
+    @UpdateTimestamp
+    var updatedAt: LocalDateTime = LocalDateTime.now()
+}


### PR DESCRIPTION
BaseEntity 추가. JPA 기본 설정을 따름 id Long
추후 Int 타입의 ID가 필요하면 추가 분리 할 것.